### PR TITLE
Only load static resources once instead of every poll

### DIFF
--- a/index.php
+++ b/index.php
@@ -9,6 +9,7 @@
 <script src="//ajax.googleapis.com/ajax/libs/jquery/1.8.2/jquery.min.js"></script>
 <script src="//netdna.bootstrapcdn.com/twitter-bootstrap/2.2.1/js/bootstrap.min.js"></script>
 <link href="//netdna.bootstrapcdn.com/twitter-bootstrap/2.2.1/css/bootstrap-combined.min.css" rel="stylesheet">
+<link rel="stylesheet" href="blinkftw.css">
 <script>
 $(document).ready(function() {
     $("#nagioscontainer").load("nagdash.php", function() { $("#spinner").fadeOut("fast"); });

--- a/nagdash.php
+++ b/nagdash.php
@@ -74,10 +74,6 @@ deep_ksort($state);
 <html>
 <head>
     <title>Nagios Dashboard</title>
-    <link href="//netdna.bootstrapcdn.com/twitter-bootstrap/2.2.1/css/bootstrap-combined.min.css" rel="stylesheet">
-    <link rel="stylesheet" href="blinkftw.css">
-    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.8.2/jquery.min.js"></script>
-    <script src="//netdna.bootstrapcdn.com/twitter-bootstrap/2.2.1/js/bootstrap.min.js"></script>
     <script>
     function showInfo(show_data) {
         $("#info-window").fadeIn("fast");


### PR DESCRIPTION
Previously various js files would be loaded every time.  Causing
memory use to grow (Chrome Dev tools said 200 MB after a few hours),
and eventually the browser to crash. For unknown reasons some of them
were also loaded with a random cache busting parameter, which probably
exacerbated the situation.
