### PR TITLE
always default to nagios-api state

### DIFF
--- a/nagdash.php
+++ b/nagdash.php
@@ -126,6 +126,7 @@ function fetch_state($hostname, $port, $protocol) {
         $state = fetch_state_livestatus($hostname, $port, $protocol);
         break;
     case "nagios-api":
+    default:
         $state = fetch_state_nagios_api($hostname, $port, $protocol);
         break;
     }


### PR DESCRIPTION
related to PR #19

This should make existing configuration backwards compatible with the new multiple APIs feature
