### PR TITLE
Update example configuration file to define $api_type

### DIFF
--- a/config.php.example
+++ b/config.php.example
@@ -1,6 +1,10 @@
 <?php
 // Config
 
+// Type of API
+// Supported values are nagios-api or livestatus
+$api_type = "nagios-api";
+
 // Your Nagios hosts
 $nagios_hosts = array(
     array("hostname" => "nagios01.dc1.company.com", "port" => "6315", "protocol" => "http", "tag" => "DC1", "tagcolour" => "#336699"), 


### PR DESCRIPTION
Attached patch updates config.php.example to define the $api_type setting. Without this setting the application just shows a blank screen with 'All Hosts OK' and 'All Services OK'
