### PR TITLE
Check for existance of cookies before using them.

### DIFF
--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -3,8 +3,14 @@ error_reporting(E_ALL ^ E_NOTICE);
 require_once('../config.php');
 require_once('../phplib/utils.php');
 
-$unwanted_hosts = unserialize($_COOKIE['nagdash_unwanted_hosts']);
+if (array_key_exists('nagdash_unwanted_hosts', $_COOKIE)) {
+    $unwanted_hosts = unserialize($_COOKIE['nagdash_unwanted_hosts']);
+} else {
+    $unwanted_hosts = array();
+}
+
 if (!is_array($unwanted_hosts)) $unwanted_hosts = array();
+
 ?>
 <html>
 <head>

--- a/htdocs/nagdash.php
+++ b/htdocs/nagdash.php
@@ -20,11 +20,20 @@ $nagios_toggle_status = array(0 => "disabled", 1 => "enabled");
 
 $sort_by_time = ( isset($sort_by_time) && $sort_by_time ) ? true : false;
 
-// Check to see if the user has a cookie that disables some hosts
-$unwanted_hosts = unserialize($_COOKIE['nagdash_unwanted_hosts']);
+// Check to see if the user has a cookie disable some nagios instances
+if (array_key_exists('nagdash_unwanted_hosts', $_COOKIE)) {
+    $unwanted_hosts = unserialize($_COOKIE['nagdash_unwanted_hosts']);
+} else {
+    $unwanted_hosts = array();
+}
+
 if (!is_array($unwanted_hosts)) $unwanted_hosts = array();
 
-$cookie_filter = $_COOKIE['nagdash_hostfilter'];
+
+// Check to see if the user has a cookie to filter out unrequired hosts
+if (array_key_exists('nagdash_hostfilter', $_COOKIE)) {
+    $cookie_filter = $_COOKIE['nagdash_hostfilter'];
+}
 
 if (!empty($cookie_filter)) {
     $filter = $cookie_filter;


### PR DESCRIPTION
Fixes instances where we try to get a value from a cookie which might
not have been set yet.

Fixes the following errors in the logs:

```
[Tue Sep 02 18:02:11 2014] [error] [client 127.0.0.1] PHP Notice:  Undefined index: nagdash_unwanted_hosts in /var/www/Nagdash/htdocs/nagdash.php on line 24, referer: http://localhost/
[Tue Sep 02 18:02:11 2014] [error] [client 127.0.0.1] PHP Notice:  Undefined index: nagdash_hostfilter in /var/www/Nagdash/htdocs/nagdash.php on line 27, referer: http://localhost/
```
