### PR TITLE
When spinner is enabled actually refresh the data

### DIFF
--- a/htdocs/js/nagdash.js
+++ b/htdocs/js/nagdash.js
@@ -27,9 +27,8 @@ function load_nagios_data(show_spinner) {
   var refreshId = setInterval(function() {
       if (show_spinner) {
         $("#spinner").fadeIn("fast");
-      } else {
-        $("#nagioscontainer").load("nagdash.php", function() { $("#spinner").fadeOut("fast"); });
       }
+      $("#nagioscontainer").load("nagdash.php", function() { $("#spinner").fadeOut("fast"); });
   }, 20000);
   $.ajaxSetup({ cache: false });
 }


### PR DESCRIPTION
This fixes the case where the spinner is enabled. If enabled all it does
is make the call to display the spinner and not actually poll for new
data.
