### PR TITLE
Add a last state change filter and handy sorting options

### DIFF
--- a/config.php.example
+++ b/config.php.example
@@ -27,6 +27,17 @@ $show_refresh_spinner = true;
 // If set to false, leave to default sorting by hostname instead.
 $sort_by_time = false;
 
+// To select by last state change, let's define some time ranges folks might
+// want to use when filtering events.
+$select_last_state_change_options = array(
+    0 => "N/A", # DO NOT MODIFY THIS VALUE
+    15 * 60 => "15 minutes",
+    60 * 60 => "1 hour",
+    60 * 60 * 12 => "12 hours",
+    60 * 60 * 24 => "1 day",
+    60 * 60 * 24 * 7 => "1 week"
+);
+
 // Enables the <blink> tag on HARD service notifications. Enable if you want more eye-catching goodness
 $enable_blinking = false;
 

--- a/htdocs/css/main.css
+++ b/htdocs/css/main.css
@@ -48,3 +48,14 @@ table#broken_hosts    tr:hover td span.controls { display:inline-block; }
                         border: 1px #848484 solid; -webkit-border-radius: 4px; -moz-border-radius: 4px; border-radius: 4px;.
                                           background: #F0F0F0; font-family: "HelveticaNeue-Medium", Helvetica, Arial, sans-serif; }
 
+.settings_group {
+    height: 25px;
+    line-height: 25px;
+}
+
+.settings_element {
+    display: inline-block;
+    float: left;
+    margin-right: 10px;
+    vertical-align: middle;
+}

--- a/htdocs/do_settings.php
+++ b/htdocs/do_settings.php
@@ -15,6 +15,18 @@ foreach ($nagios_hosts as $host) {
 $hostfilter = $_POST["hostfilter"];
 unset($_POST["hostfilter"]);
 setcookie('nagdash_hostfilter', $hostfilter, time()+60*60*24*365);
+$select_last_state_change = $_POST['select_last_state_change'] ? $_POST['select_last_state_change'] : "0";
+setcookie('select_last_state_change', $select_last_state_change, time()+60*60*24*365);
+if (isset($_POST['sort_by_time'])) {
+    setcookie('sort_by_time', '1', time()+60*60*24*365);
+} else {
+    setcookie('sort_by_time', '0', time()+60*60*24*365);
+}
+if (isset($_POST['sort_descending'])) {
+    setcookie('sort_descending', '1', time()+60*60*24*365);
+} else {
+    setcookie('sort_descending', '0', time()+60*60*24*365);
+}
 
 $submitted_hosts = $_POST;
 $unwanted_hosts = array_diff($hosts, array_keys($submitted_hosts));

--- a/htdocs/nagdash.php
+++ b/htdocs/nagdash.php
@@ -144,7 +144,7 @@ if (count($known_hosts) > 0) {
     <tr><th width="30%">Hostname</th><th width="50%">Service</th><th width="10%">Duration</th><th width="5%">Attempt</th></tr>
 <?php
     // Check for the presence of the 'sort_by_time' cookie, then the static config value.
-    if ($filter_sort_by_time || $sort_by_time) {
+    if ((isset($filter_sort_by_time) && $filter_sort_by_time == 1) || $sort_by_time) {
         usort($broken_services,'NagdashHelpers::cmp_last_state_change');
     }
     foreach($broken_services as $service) {
@@ -169,7 +169,7 @@ if (count($known_hosts) > 0) {
 <?php }
 
 // Check for the presence of the 'sort_by_time' cookie, then the static config value.
-if ($filter_sort_by_time || $sort_by_time) {
+if ((isset($filter_sort_by_time) && $filter_sort_by_time == 1) || $sort_by_time) {
     usort($known_services,'NagdashHelpers::cmp_last_state_change');
 }
 

--- a/htdocs/nagdash.php
+++ b/htdocs/nagdash.php
@@ -39,6 +39,27 @@ if (!empty($cookie_filter)) {
     $filter = $cookie_filter;
 }
 
+// If the user wants to filter by last state change, grab the filter value.
+// Else default to '0' (we won't filter by last state change).
+// IDEA: Perhaps we create a $filter array tp pass to
+// NagdashHelpers::parse_nagios_host_data() that contains the values of 'hostfilter',
+// 'select_last_state_change', 'sort_by_time', and 'sort_descending'.
+if (isset($_COOKIE['select_last_state_change'])) {
+    $filter_select_last_state_change = (int) $_COOKIE['select_last_state_change'];
+} else {
+    $filter_select_last_state_change = 0;
+}
+
+// If 1, the user wants to sort by time; 0 if not.
+if (isset($_COOKIE['sort_by_time'])) {
+    $filter_sort_by_time = (int) $_COOKIE['sort_by_time'];
+}
+
+// If 1, the user wants to sort descending; 0 if not.
+if (isset($_COOKIE['sort_descending'])) {
+    $filter_sort_descending = (int) $_COOKIE['sort_descending'];
+}
+
 // Collect the API data from each Nagios host.
 
 if (isset($mock_state_file)) {
@@ -62,7 +83,7 @@ if (count($errors) > 0) {
         echo "<div class='status_red'>{$error}</div>";
     }
 }
-list($host_summary, $service_summary, $down_hosts, $known_hosts, $known_services, $broken_services) = NagdashHelpers::parse_nagios_host_data($state, $filter, $api_cols);
+list($host_summary, $service_summary, $down_hosts, $known_hosts, $known_services, $broken_services) = NagdashHelpers::parse_nagios_host_data($state, $filter, $api_cols, $filter_select_last_state_change);
 ?>
 
 <div id="info-window"><button class="close" onClick='$("#info-window").fadeOut("fast");'>&times;</button><div id="info-window-text"></div></div>
@@ -122,7 +143,8 @@ if (count($known_hosts) > 0) {
     <table class="widetable" id="broken_services">
     <tr><th width="30%">Hostname</th><th width="50%">Service</th><th width="10%">Duration</th><th width="5%">Attempt</th></tr>
 <?php
-    if ($sort_by_time) {
+    // Check for the presence of the 'sort_by_time' cookie, then the static config value.
+    if ($filter_sort_by_time || $sort_by_time) {
         usort($broken_services,'NagdashHelpers::cmp_last_state_change');
     }
     foreach($broken_services as $service) {
@@ -146,7 +168,8 @@ if (count($known_hosts) > 0) {
     <table class="widetable status_green"><tr><td><b>All services OK</b></td></tr></table>
 <?php }
 
-if ($sort_by_time) {
+// Check for the presence of the 'sort_by_time' cookie, then the static config value.
+if ($filter_sort_by_time || $sort_by_time) {
     usort($known_services,'NagdashHelpers::cmp_last_state_change');
 }
 

--- a/htdocs/nagdash.php
+++ b/htdocs/nagdash.php
@@ -86,7 +86,7 @@ list($host_summary, $service_summary, $down_hosts, $known_hosts, $known_services
         echo "</span></td>";
         echo "<td><blink>{$nagios_host_status[$host['host_state']]}</blink></td>";
         echo "<td>{$host['duration']}</td>";
-        echo "<td>{$host['current_attempt']}/{$host['max_attempts']}</td>";
+        echo "<td>{$host['current_attempt']}/{$host['max_check_attempts']}</td>";
         echo "<td class=\"desc\">{$host['detail']}</td>";
         echo "</tr>";
     }

--- a/htdocs/settings_dialog.php
+++ b/htdocs/settings_dialog.php
@@ -1,4 +1,4 @@
-<?php require_once '../config.php'; ?>
+<?php require '../config.php'; ?>
 <div id="settings_modal" class="modal hide fade" tabindex="-1" role="dialog" aria-hidden="true">
 <div class="modal-header">
   <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</a></button>
@@ -26,12 +26,15 @@
 <div class="settings_group">
 <span class="settings_element">
 <select name="select_last_state_change" style="width:110px;">
-    <option value="0">N/A</option>
-    <option value="<?php echo(15 * 60) ?>">15 minutes</option>
-    <option value="<?php echo(60 * 60) ?>">1 hour</option>
-    <option value="<?php echo(60 * 60 * 12) ?>">12 hours</option>
-    <option value="<?php echo(60 * 60 * 24) ?>">1 day</option>
-    <option value="<?php echo(60 * 60 * 24 * 7) ?>">1 week</option>
+<?php
+foreach ($select_last_state_change_options as $time_in_seconds => $time_in_english) {
+    $selected_last_state_change_option = "";
+    if (isset($_COOKIE['select_last_state_change']) && $_COOKIE['select_last_state_change'] == $time_in_seconds) {
+        $selected_last_state_change_option = "selected";
+    }
+    echo "<option value=" . $time_in_seconds . " " . $selected_last_state_change_option . ">" . $time_in_english . "</option>";
+}
+?>
 </select>
 </span>
 <span class="settings_element"> ago</span>

--- a/htdocs/settings_dialog.php
+++ b/htdocs/settings_dialog.php
@@ -1,3 +1,4 @@
+<?php require_once '../config.php'; ?>
 <div id="settings_modal" class="modal hide fade" tabindex="-1" role="dialog" aria-hidden="true">
 <div class="modal-header">
   <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</a></button>
@@ -21,6 +22,52 @@
 <legend>Hostname regex</legend>
 <input type="input" name="hostfilter" value="<?php echo $_COOKIE['nagdash_hostfilter']; ?>">
 </fieldset>
+<legend>Last state change</legend>
+<div class="settings_group">
+<span class="settings_element">
+<select name="select_last_state_change" style="width:110px;">
+    <option value="0">N/A</option>
+    <option value="<?php echo(15 * 60) ?>">15 minutes</option>
+    <option value="<?php echo(60 * 60) ?>">1 hour</option>
+    <option value="<?php echo(60 * 60 * 12) ?>">12 hours</option>
+    <option value="<?php echo(60 * 60 * 24) ?>">1 day</option>
+    <option value="<?php echo(60 * 60 * 24 * 7) ?>">1 week</option>
+</select>
+</span>
+<span class="settings_element"> ago</span>
+<legend>Sort options</legend>
+<?php
+// If the config option 'sort_by_time' is true, check if the user is overriding it.
+// If not, let the config option take effect.
+$checked_sort_by_time = "";
+$checked_sort_descending = "";
+if ($sort_by_time) {
+    if (isset($_COOKIE['sort_by_time']) && $_COOKIE['sort_by_time'] == '0') {
+        $checked_sort_by_time = "";
+    } else {
+        $checked_sort_by_time = "checked";
+    }
+} elseif (isset($_COOKIE['sort_by_time']) && $_COOKIE['sort_by_time'] == '1') {
+    $checked_sort_by_time = "checked";
+}
+// Does the user want to sort in descending order?
+if (isset($_COOKIE['sort_descending']) && $_COOKIE['sort_descending'] == '1') {
+        $checked_sort_descending = "checked";
+}
+echo '<span class="settings_element">';
+echo 'Sort by time?';
+echo '<label class="checkbox inline tag_label">';
+echo '<input type="checkbox" name="sort_by_time"' . $checked_sort_by_time . '>';
+echo '</label>';
+echo '</span>';
+echo '<span class="settings_element">';
+echo 'Descending?';
+echo '<label class="checkbox inline tag_label">';
+echo '<input type="checkbox" name="sort_descending"' . $checked_sort_descending . '>';
+echo '</label>';
+echo '</span>';
+?>
+</div>
 </form>
 </div>
 <div class="modal-footer">

--- a/htdocs/settings_dialog.php
+++ b/htdocs/settings_dialog.php
@@ -57,19 +57,19 @@ if ($sort_by_time) {
 if (isset($_COOKIE['sort_descending']) && $_COOKIE['sort_descending'] == '1') {
         $checked_sort_descending = "checked";
 }
-echo '<span class="settings_element">';
-echo 'Sort by time?';
-echo '<label class="checkbox inline tag_label">';
-echo '<input type="checkbox" name="sort_by_time"' . $checked_sort_by_time . '>';
-echo '</label>';
-echo '</span>';
-echo '<span class="settings_element">';
-echo 'Descending?';
-echo '<label class="checkbox inline tag_label">';
-echo '<input type="checkbox" name="sort_descending"' . $checked_sort_descending . '>';
-echo '</label>';
-echo '</span>';
 ?>
+<span class="settings_element">
+Sort by time?
+<label class="checkbox inline tag_label">
+<?php echo '<input type="checkbox" name="sort_by_time"' . $checked_sort_by_time . '>'; ?>
+</label>
+</span>
+<span class="settings_element">
+Descending?
+<label class="checkbox inline tag_label">
+<?php echo '<input type="checkbox" name="sort_descending"' . $checked_sort_descending . '>'; ?>
+</label>
+</span>
 </div>
 </form>
 </div>

--- a/phplib/timeago.php
+++ b/phplib/timeago.php
@@ -25,11 +25,10 @@ function timeago($referencedate=0, $timepointer='', $measureby='', $autotext=tru
     
     $datedifference = floor($Clean/$calc[$usemeasure][0]);    ## Rounded date difference
     
+    $prospect = ' ago'; # Default
     if($autotext==true && ($timepointer==time())){
         if($Raw < 0){
             $prospect = ' from now';
-        }else{
-            $prospect = ' ago';
         }
     }
     


### PR DESCRIPTION
- Filter by last state change with values defined in the config file. Suggested times are of the last 15 minutes, 1 hour, 12 hours, 1 day, and 1 week.
- Expose the ``$sort_by_time`` config value as a checkbox in the settings dialog. Allow the user to override it and store that value in a cookie.
- Allow the output to be sorted in descending order. This works for the default (hostnames) view and sorting by time.

I think I'll still owe you a minor update to the ``README`` about these feature updates, and probably a 5-minute demo.