### PR TITLE
Respond only to "s" keypress for settings

### DIFF
--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -35,8 +35,10 @@ if (!is_array($unwanted_hosts)) $unwanted_hosts = array();
 
 
 <script>
-    $(document).keypress("s", function(e) {
-        $("#settings_modal").modal();
+    $(document).keypress(function(e) {
+        if (e.which == 115) { // "s"
+            $("#settings_modal").modal();
+        }
     });
     $(document).ready(load_nagios_data(<?php echo ($show_refresh_spinner === true)?>));
 </script>


### PR DESCRIPTION
Before we were responding to any keypress as we didn't check which key was pressed in the callback. As per [keypress](https://api.jquery.com/keypress/) documentation, we should check the character code in the callback before acting upon it.