### PR TITLE
Add ability to provide custom comment when Ack-ing a service alert. Provide a fix for issue #50.

### DIFF
--- a/config.php.example
+++ b/config.php.example
@@ -47,6 +47,9 @@ $enable_blinking = false;
 // Include more css after the default; useful for custom skin
 $extra_css = none;
 
+// Show instructions for accessing settings panel
+$show_settings_instructions = true;
+
 # For testing, uncomment this for some errors:
 //$mock_state_file = './test_data/state';
 

--- a/htdocs/controls.php
+++ b/htdocs/controls.php
@@ -1,12 +1,23 @@
 <div class="btn-group">
+	<div class="btn-group">
+	<a href='#' class='btn btn-mini dropdown-toggle' data-toggle='dropdown' > <i class='icon-comment'></i> Ack </a>
+	<ul class="dropdown-menu pull-left" >
+	  <li id='ack-comment-container'>
+	  	<input type="text" class="form-control" placeholder="Ack Comment" id="ack-comment">
+			<?php
+				echo "<a href='#' class='btn btn-mini' onClick=\"nagios_action('{$tag}', '{$host}', '{$service}', 'ack', $(this).siblings('#ack-comment').val()); $(this).siblings('#ack-comment').val(''); return false;\" >  <i class='icon-check'></i></a>";
+			?>
+	  </li>
+	</ul>
+</div>
 <?php
-echo "<a href='#' onClick=\"nagios_action('{$tag}', '{$host}', '{$service}', 'ack'); return false;\" class='btn btn-mini'> <i class='icon-check'></i> Ack </a>";
 $action = (!isset($service['is_enabled'])) ? "disable" : "enable";
 $text   = (!isset($service['is_enabled'])) ? "Silence" : "Unsilence";
 $control = "<a href='#' onClick=\"nagios_action('{$tag}', '{$host}', '{$service}', '{$action}'); return false;\" class='btn btn-mini'>";
 $control .= "<i class='icon-volume-off'></i> {$text}</a>";
 echo $control;
 ?>
+<div class="btn-group">
 <a class="btn btn-mini dropdown-toggle" data-toggle="dropdown" href="#">
 <i class="icon-time"></i> Downtime <span class="caret"></span></a>
 <ul class="dropdown-menu pull-right">
@@ -20,3 +31,15 @@ echo $control;
 ?>
     </ul>
 </div>
+</div>
+<script>
+	// This has to be done on each Ajax refresh.
+    $(function() {
+      // Setup drop down menu
+      $('.dropdown-toggle').dropdown();
+      // Fix input element click problem
+      $('.dropdown-menu').click(function(e) {
+        e.stopPropagation();
+      });
+    });
+</script>

--- a/htdocs/css/main.css
+++ b/htdocs/css/main.css
@@ -47,15 +47,8 @@ table#broken_hosts    tr:hover td span.controls { display:inline-block; }
 #spinner    { position: absolute; top: 10px; width: 300px; text-align: center; left: 50%; margin-left: -150px;
                         border: 1px #848484 solid; -webkit-border-radius: 4px; -moz-border-radius: 4px; border-radius: 4px;.
                                           background: #F0F0F0; font-family: "HelveticaNeue-Medium", Helvetica, Arial, sans-serif; }
-
-.settings_group {
-    height: 25px;
-    line-height: 25px;
-}
-
-.settings_element {
-    display: inline-block;
-    float: left;
-    margin-right: 10px;
-    vertical-align: middle;
-}
+.settings_group { height: 25px; line-height: 25px; }
+.settings_element { display: inline-block; float: left; margin-right: 10px; vertical-align: middle; }
+#ack-comment-container { padding:0.5em; }
+#ack-comment-container input { margin:0; width:80%; height:23px; }
+#ack-comment-container a { width:12%; display:inline-block; padding-left: 2%; padding-right: 2%;}

--- a/htdocs/css/main.css
+++ b/htdocs/css/main.css
@@ -52,3 +52,5 @@ table#broken_hosts    tr:hover td span.controls { display:inline-block; }
 #ack-comment-container { padding:0.5em; }
 #ack-comment-container input { margin:0; width:80%; height:23px; }
 #ack-comment-container a { width:12%; display:inline-block; padding-left: 2%; padding-right: 2%;}
+#settings-note { float:right; opacity:0.1; transition: .25s ease-in-out; -moz-transition: .25s ease-in-out; -webkit-transition: .25s ease-in-out; }
+#settings-note:hover { opacity:0.9; }

--- a/htdocs/do_action.php
+++ b/htdocs/do_action.php
@@ -12,12 +12,13 @@ if (!isset($_POST['nag_host'])) {
 } else {
     $nagios_instance = $_POST['nag_host'];
     $action = $_POST['action'];
+    $comment = $action == "ack" && isset($_POST['attribute']) ? $_POST['attribute'] : "{$action} from Nagdash";
     $details = [
             "host" => $_POST['hostname'],
             "service" => ($_POST['service']) ? $_POST['service'] : null,
             "author" => function_exists("nagdash_get_user") ? nagdash_get_user() : "Nagdash",
-            "duration" => ($_POST['duration']) ? ($_POST['duration'] * 60) : null,
-            "comment" => "{$action} from Nagdash"
+            "duration" => ($_POST['attribute']) ? ($_POST['attribute'] * 60) : null,
+            "comment" => $comment
             ];
 
 

--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -38,7 +38,11 @@ document.refresh_every_ms = <?php echo (isset($refresh_every_ms) ? $refresh_ever
 <body>
   <div id="spinner"><h3><img src="images/ajax-loader.gif" align="absmiddle"> Refreshing...</h3></div>
   <div id="nagioscontainer"></div>
-  <?php NagdashHelpers::render("settings_dialog.php", ["nagios_hosts" => $nagios_hosts,
+  <?php
+  if ($show_settings_instructions) {
+        echo "<span id='settings-note'>Press 's' for settings.</span>";
+    }
+  NagdashHelpers::render("settings_dialog.php", ["nagios_hosts" => $nagios_hosts,
                                                        "unwanted_hosts" => $unwanted_hosts]);?>
 
 

--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -44,7 +44,7 @@ document.refresh_every_ms = <?php echo (isset($refresh_every_ms) ? $refresh_ever
 
 <script>
     $(document).keypress(function(e) {
-        if (e.which == 115) { // "s"
+        if (e.which == 115 && !$(".controls div").hasClass("open")) { // "s"
             $("#settings_modal").modal();
         }
     });

--- a/htdocs/js/nagdash.js
+++ b/htdocs/js/nagdash.js
@@ -41,16 +41,13 @@ function load_nagios_data(show_spinner) {
  *   host    - host to apply the action to
  *   service - the service to apply the action to
  *   action  - the actual action to do
- *   minutes - minutes to downtime (only for downtime action)
+ *   attr - arbitrary attribute related to action
  *
  */
-function nagios_action(tag, host, service, action, minutes) {
+function nagios_action(tag, host, service, action, attr) {
   $.post('do_action.php', { nag_host: tag,
                             hostname: host,
                             service: service,
                             action: action,
-                            duration: minutes}, function(data) { showInfo(data) } );
+                            attribute: attr}, function(data) { showInfo(data) } );
 }
-
-
-


### PR DESCRIPTION
This PR provides the ability for users to submit a custom comment when Ack-ing a service alert - we use this heavily at Ookla so the team knows why and who is handling an alert. If the field is left blank, the comment will fall back onto the default nagdash comment. Screenshot of UI change is here: http://ookla.d.pr/17KI1

Also provide a fix for: https://github.com/lozzd/Nagdash/issues/50
